### PR TITLE
Fixed direct importing of WeakSet and updated import lines in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Same as a *list* except that when a weakref-able variable is deleted, it is remo
 
    .. code-block:: python
 
-      from weakref import WeakList
+      from weakreflist import WeakList
 
       class A(object):
           """weakrefs don't function directly on object()"""
@@ -62,7 +62,7 @@ Same as a *list* except that when a weakref-able variable is deleted, it is remo
 
    .. code-block:: python
 
-      from weakref import WeakList
+      from weakreflist import WeakList
       import gc
 
       class A(object):

--- a/weakreflist/__init__.py
+++ b/weakreflist/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf8 -*-
+from .weakreflist import WeakList
+
 __all__ = ['weakreflist']


### PR DESCRIPTION
I made a small change to the importing, as I couldn't get the import style shown in the readme (`from weakref import WeakList`) nor the obvious (`from weakreflist import WeakList`) to work (CPython 3.5). Instead I was having to use `from weakreflist import weakreflist` and `WeakSet = weakreflist.WeakSet`, or similar.

Also updated the readme to show the new imports. Tested with my python but not 2.7 or any other implementation.

I'm new to this, so apologies if I went about this the wrong way.