### PR TITLE
Documentation changes and various typo fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,96 +1,116 @@
 ***********
 weakreflist
 ***********
+--------------------------------------------------------------------
+A WeakList class for storing objects using weak references in a list
+--------------------------------------------------------------------
 
 .. image:: https://pypip.in/v/weakreflist/badge.png
-        :target: https://pypi.python.org/pypi/weakreflist
-
----------------------------------------------------------------------
-A WeakList class for storing objects using weak references in a list.
----------------------------------------------------------------------
-
+  :target: https://pypi.python.org/pypi/weakreflist
 
 **Table of Contents**
 
-
 .. contents::
-    :local:
-    :depth: 1
-    :backlinks: none
+   :local:
+   :depth: 1
+   :backlinks: none
 
 
-=============
+============
 Installation
-=============
+============
 
-Install it from pypi::
+Install it from PyPi::
 
   pip install weakreflist
 
-or from sources::
+or from Github::
 
   git clone git@github.com:apieum/weakreflist.git
   cd weakreflist
   python setup.py install
 
+
 =====
 Usage
 =====
-Same as a *list* except that when a weakref-able variable is deleted, it is removed from the list.
+
+``WeakList`` provides the same methods as the built-in ``list`` but will remove any ``weakref``-compatible objects that
+are released by the garbage collector.
+
 
 **Example for CPython:**
 
-   .. code-block:: python
+  .. code-block:: python
 
-      from weakreflist import WeakList
+    from weakreflist import WeakList
 
-      class A(object):
-          """weakrefs don't function directly on object()"""
-      objectA = A()
-      my_list = WeakList([objectA])
-      assert len(my_list) == 1
-      del objectA
-      assert len(my_list) == 0 # objectA removed from list
+    class A(object):
+        """weakrefs don't function directly on object()"""
+
+    objectA = A()
+    my_list = WeakList([objectA])
+    assert len(my_list) == 1
+    del objectA
+    assert len(my_list) == 0 # objectA removed from list
 
 
 *Note:*
-   Pypy (probably jython, cython...) have a different implementation of garbage collector and it is known that weakrefs doesn't function the same way.
+  Pypy has a different implementation of garbage collection which changes some behavior of ``weakref``.
+  This may be true in other 3\ :superscript:`rd`-party compilers such as Jython and Cython. 
+  Some interactive interpreters, like IPython, `may also delay calls to <http://stackoverflow.com/a/12023927/1993468>`_
+  ``gc``.
 
-   You need to explicitly call gc.collect() which has an impact on performance.
+  Due to this, you will need to explicitly call ``gc.collect()`` which has a negative impact on performance!
 
-**Example for other python implementations**
+**Example for other Python implementations**
 
-   .. code-block:: python
+  .. code-block:: python
 
-      from weakreflist import WeakList
-      import gc
+    from weakreflist import WeakList
+    import gc
 
-      class A(object):
-          """weakrefs don't function directly on object()"""
-      objectA = A()
-      my_list = WeakList([objectA])
-      assert len(my_list) == 1
-      del objectA
+    class A(object):
+        """weakrefs don't function directly on object()"""
 
-      assert len(my_list) == 1 # gc not done
-      gc.collect() # must be called
-      assert len(my_list) == 0
+    objectA = A()
+    my_list = WeakList([objectA])
+    assert len(my_list) == 1
+    del objectA
+
+    assert len(my_list) == 1 # gc did not run
+    gc.collect() # must be called explicitly
+    assert len(my_list) == 0
 
 
 ===========
 Development
 ===========
 
-Your feedback, code review, improvements or bugs, and help to document is appreciated.
-You can contact me by mail: apieum [at] gmail [dot] com
+Your feedback, code review, improvements, bug reports, and help to document is appreciated.
+You can contact me by email: apieum [at] gmail [dot] com
 
-Test recommended requirements::
+Setup
+-----
+
+Install recommended packages for running tests::
 
   pip install -r dev-requirements.txt
 
-Sometimes --spec-color doesn't function. Uninstall nosespec and nosecolor then reinstall nosecolor and nosespec separatly in this order (nosecolor first).
+*Note:*
+  Sometimes `--spec-color` doesn't function. This can potentially be fixed by the following:
 
-Launch tests::
+  #. Uninstall ``nosespec`` and ``nosecolor``
+  #. Reinstall ``nosecolor`` alone
+  #. Reinstall ``nosespec``
+
+  Be certain to reinstall them separately and in the order given, otherwise you will continue
+  to experience the same issue!
+
+Run tests
+---------
+
+::
 
   git clone git@github.com:apieum/weakreflist.git
   cd weakreflist
@@ -99,16 +119,15 @@ Launch tests::
   # nosetests --with-spec --spec-color --with-watch ./weakreflist
 
 
-
 ============
 Contributors
 ============
 
-Thanks to `BoonsNaibot <https://github.com/BoonsNaibot>`_ to have contributed to:
+Thanks to `BoonsNaibot <https://github.com/BoonsNaibot>`_ for the following contributions:
   * extended slicing support
-  * \_\_reversed\_\_, count, extend, insert methods.
+  * `__reversed__`, `count`, `extend`, and `insert` methods.
 
 
 
 .. image:: https://secure.travis-ci.org/apieum/weakreflist.png?branch=master
-   :target: https://travis-ci.org/apieum/weakreflist
+  :target: https://travis-ci.org/apieum/weakreflist

--- a/weakreflist/testDocExamples.py
+++ b/weakreflist/testDocExamples.py
@@ -2,30 +2,32 @@
 import unittest
 from .weakreflist import WeakList
 import sys
-is_pypy = '__pypy__' in sys.builtin_module_names
-if is_pypy:
-    import gc
+is_pypy = "__pypy__" in sys.builtin_module_names
+
 
 class DocExampleTest(unittest.TestCase):
     if not is_pypy:
         def test_example1(self):
             class A(object):
                 """weakrefs don't function directly on object()"""
+
             objectA = A()
             my_list = WeakList([objectA])
             assert len(my_list) == 1
             del objectA
-            assert len(my_list) == 0 # objectA removed from list
+            assert len(my_list) == 0  # objectA removed from list
     else:
         def test_example2(self):
             import gc
+
             class A(object):
                 """weakrefs don't function directly on object()"""
+
             objectA = A()
             my_list = WeakList([objectA])
             assert len(my_list) == 1
             del objectA
 
-            assert len(my_list) == 1 # gc not done
-            gc.collect() # must be called
+            assert len(my_list) == 1  # gc did not run
+            gc.collect()  # must be called
             assert len(my_list) == 0

--- a/weakreflist/testweakreflist.py
+++ b/weakreflist/testweakreflist.py
@@ -3,16 +3,18 @@ import weakref
 import unittest
 from .weakreflist import WeakList
 import sys
-is_pypy = '__pypy__' in sys.builtin_module_names
+is_pypy = "__pypy__" in sys.builtin_module_names
 if is_pypy:
     import gc
 
 
 class WeakrefListTest(unittest.TestCase):
+
     class objectFake(object):
-        __count__= 0
+        __count__ = 0
+
         def __init__(self):
-            type(self).__count__ +=1
+            type(self).__count__ += 1
             self.index = type(self).__count__
 
         def __gt__(self, other):
@@ -33,12 +35,12 @@ class WeakrefListTest(unittest.TestCase):
     def test_it_is_instance_of_list(self):
         self.assertIsInstance(self.wr_list, list)
 
-    def test_it_store_a_weakref_ref(self):
+    def test_it_stores_a_weakref_ref(self):
         fake_obj = self.objectFake()
         self.wr_list.append(fake_obj)
         self.assertIsInstance(self.ref_item(0), weakref.ReferenceType)
 
-    def test_if_a_weakref_already_stored_it_reuse_it(self):
+    def test_if_a_weakref_is_already_stored_it_reuses_it(self):
         fake_obj = self.objectFake()
         self.wr_list.append(fake_obj)
         self.wr_list.append(fake_obj)
@@ -52,7 +54,7 @@ class WeakrefListTest(unittest.TestCase):
         self.assertTrue(fake_obj0 in self.wr_list)
         self.assertFalse(fake_obj1 in self.wr_list)
 
-    def test_when_all_object_instance_are_deleted_all_ref_in_list_are_deleted(self):
+    def test_when_all_bindings_to_an_object_are_deleted_all_ref_in_list_are_deleted(self):
         fake_obj = self.objectFake()
         self.wr_list.append(fake_obj)
         self.wr_list.append(fake_obj)
@@ -107,15 +109,14 @@ class WeakrefListTest(unittest.TestCase):
     def test_it_supports_addition(self):
         fake_obj = self.objectFake()
         expected = WeakList([fake_obj])
-        self.wr_list+= expected
+        self.wr_list += expected
         self.assertEqual(expected, self.wr_list)
         self.assertEqual(1, len(self.wr_list))
-
 
     def test_addition_update_finalizer(self):
         fake_obj = self.objectFake()
         wr_list = WeakList([fake_obj])
-        self.wr_list+= wr_list
+        self.wr_list += wr_list
         del fake_obj
         if is_pypy:
             gc.collect()
@@ -178,7 +179,7 @@ class WeakrefListTest(unittest.TestCase):
         self.assertEqual(self.wr_list[1:], [1, 2])
         self.assertEqual(3, len(self.wr_list))
 
-    def test_it_can_set_slice_on_objets(self):
+    def test_it_can_set_slice_on_objects(self):
         fake_obj0 = self.objectFake()
         fake_obj1 = self.objectFake()
         self.wr_list.append(fake_obj0)
@@ -274,6 +275,7 @@ class WeakrefListTest(unittest.TestCase):
     def test_it_supports_sort_with_key(self):
         def index_plus_2_if_odd(item):
             return item.index + 2 if item.index % 2 != 0 else item.index
+
         fake_obj0 = self.objectFake()
         fake_obj1 = self.objectFake()
         self.wr_list.extend([fake_obj1, fake_obj0])
@@ -298,6 +300,7 @@ class WeakrefListTest(unittest.TestCase):
         def test_it_supports_sort_with_key_and_cmp(self):
             def index_plus_2_if_odd(item):
                 return item.index + 2 if item.index % 2 != 0 else item.index
+
             def compare(item1, item2):
                 return cmp(item2, item1)
 
@@ -307,7 +310,6 @@ class WeakrefListTest(unittest.TestCase):
             expected = WeakList(sorted(list(self.wr_list), cmp=compare, key=index_plus_2_if_odd))
             self.wr_list.sort(cmp=compare, key=index_plus_2_if_odd)
             self.assertEqual(expected, self.wr_list)
-
 
 
 if __name__ == "__main__":

--- a/weakreflist/weakreflist.py
+++ b/weakreflist/weakreflist.py
@@ -4,11 +4,13 @@ import sys
 
 __all__ = ["WeakList"]
 
+
 def is_slice(index):
     return isinstance(index, slice)
 
 
 class WeakList(list):
+
     def __init__(self, items=list()):
         list.__init__(self, self._refs(items))
 
@@ -57,8 +59,13 @@ class WeakList(list):
     def count(self, item):
         return list.count(self, self.ref(item))
 
-    def pop(self, item):
-        return list.pop(self, self.ref(item))
+    def pop(self, index):
+        """
+        Pops an item from the list at the given index
+
+        :rtype: weakref
+        """
+        return list.pop(self, self.ref(index))
 
     def insert(self, index, item):
         return list.insert(self, index, self.ref(item))
@@ -76,7 +83,7 @@ class WeakList(list):
         return map(self.value, items)
 
     def _sort_key(self, key=None):
-        return self.value if key == None else lambda item: key(self.value(item))
+        return self.value if key is None else lambda item: key(self.value(item))
 
     if sys.version_info < (3,):
         def sort(self, cmp=None, key=None, reverse=False):


### PR DESCRIPTION
Forgive me if this seemed a little nit-picky; these changes are meant to clarify some use cases, add consistency, and correct some spacing. 

________

**Audit of changes**

* Modified README.rst
  * Moved label of repo (lines 8-11) to act as a subtitle (placed immediately after section heading)
  * Changed indentation of `contents` to 3 in order to match `toctree` specification
  * Using two backticks for package and class names; one backtick for commands, methods, and variable names
  * Added warning that IPython may not call ``gc`` and linked to source

* Replaced single-quotes with double-quotes for consistency across files
* Padded operator assignments (ex. `+=1` --> `+= 1`)
* Removed a redundant `import` statement ([**may want to review**](https://github.com/apieum/weakreflist/compare/master...kamakazikamikaze:dev?expand=1#diff-f6e6544c15356b39cc07a8226b6e79e5))
* Changed a test function name to use "[bind](https://docs.python.org/2/reference/executionmodel.html)" instead of "instance" for clarity
* Added docstring to `WeakList.pop` and changed parameter name from `item` to `index` to reflect expected value type