### PR TITLE
Tweaking __all__ to make sure WeakList class isn't private

### DIFF
--- a/weakreflist/__init__.py
+++ b/weakreflist/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf8 -*-
 from .weakreflist import WeakList
 
-__all__ = ['weakreflist']
+__all__ = ['WeakList']


### PR DESCRIPTION
Just a very minor tweak, to WeakList isn't a private member. Previously importing in the expected way: `from weaklistref import WeakList`, you were actually importing a private member and it gets flagged by inspections with a warning (in PyCharm for example). This tweak adds the class properly to `__all__` making it a public member.